### PR TITLE
Fix: remove deprecated experimental.appDir for Next 16

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,9 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  experimental: {
-    appDir: true, // 👈 asegura que Next use /src/app correctamente
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove experimental.appDir option to resolve deprecation in Next.js 16