### PR TITLE
Fix: unused req/next params in routes and server

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -28,7 +28,7 @@ const router: Router = Router();
  *                   type: string
  *                   format: date-time
  */
-router.get("/health", (req: Request, res: Response) => {
+router.get("/health", (_req: Request, res: Response) => {
   res.json({
     status: "OK",
     message: "Server is running",

--- a/backend/src/routes/test.routes.ts
+++ b/backend/src/routes/test.routes.ts
@@ -30,7 +30,7 @@ const router: Router = Router();
  *                       type: string
  *                       format: date-time
  */
-router.get("/", (req: Request, res: Response) => {
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     success: true,
     message: "Test endpoint trabajando!",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -23,7 +23,7 @@ app.use("/api/v1/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use("/api", routes);
 
 // Root endpoint
-app.get("/", (req: Request, res: Response) => {
+app.get("/", (_req: Request, res: Response) => {
   res.json({
     message: "Bienvenido a la API de Footalent",
     version: "1.0.0",
@@ -33,7 +33,7 @@ app.get("/", (req: Request, res: Response) => {
 });
 
 // 404 handler
-app.use((req: Request, res: Response) => {
+app.use((_req: Request, res: Response) => {
   res.status(404).json({
     success: false,
     message: "Ruta no encontrada",
@@ -42,7 +42,7 @@ app.use((req: Request, res: Response) => {
 
 // Error handler
 app.use(
-  (err: Error, req: Request, res: Response, next: express.NextFunction) => {
+  (err: Error, _req: Request, res: Response, _next: express.NextFunction) => {
     console.error(err.stack);
     res.status(500).json({
       success: false,


### PR DESCRIPTION
## Summary by Sourcery

Address linting errors by prefixing unused Express handler parameters with an underscore

Chores:
- Rename unused \u0060req\u0060 parameters to \u0060_req\u0060 in the root, health, and test endpoints
- Rename unused \u0060req\u0060 and \u0060next\u0060 parameters to \u005Freq\u005F and \u005Fnext\u005F in the 404 and error middleware