### PR TITLE
TASK (Reporte QA): Validación en el uso de puntos en el campo email

### DIFF
--- a/frontend/src/app/(public)/login/page.tsx
+++ b/frontend/src/app/(public)/login/page.tsx
@@ -5,6 +5,7 @@ import { useForm, SubmitHandler, FieldValues } from "react-hook-form";
 import FormRow from "@/src/components/FormRow";
 import SubmitButton from "@/src/components/SubmitButton";
 import Link from "next/link";
+import { emailInvalidMessage, isValidEmail } from "@/src/utils/validators";
 
 //const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));  //esta linea sirve para visualizar la carga
 
@@ -90,6 +91,8 @@ const Login: React.FC = () => {
                   message:
                     "Por favor, proporcione una dirección de correo electrónico válida.",
                 },
+                validate: (value: string) =>
+                  isValidEmail(value) || emailInvalidMessage,
               })}
             />
           </FormRow>

--- a/frontend/src/app/(public)/register/page.tsx
+++ b/frontend/src/app/(public)/register/page.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { useRegister } from "@/src/hooks/useRegister";
 import { useRouter } from "next/navigation";
+import { isValidEmail, emailInvalidMessage } from "@/src/utils/validators";
 
 interface RegisterFormInputs {
   name: string;
@@ -98,8 +99,11 @@ const Register: React.FC = () => {
                 required: "Este campo es obligatorio",
                 pattern: {
                   value: /\S+@\S+\.\S+/,
-                  message: "Proporcione un correo electrónico válido.",
+                  message:
+                    "Por favor, proporcione una dirección de correo electrónico válida.",
                 },
+                validate: (value: string) =>
+                  isValidEmail(value) || emailInvalidMessage,
               })}
             />
           </FormRow>

--- a/frontend/src/utils/validators.ts
+++ b/frontend/src/utils/validators.ts
@@ -1,0 +1,24 @@
+export const isValidEmail = (email: string): boolean => {
+  if (!email || typeof email !== "string") return false;
+
+  // No spaces
+  if (/\s/.test(email)) return false;
+
+  // Must have exactly one @ and non-empty local and domain parts
+  const parts = email.split("@");
+  if (parts.length !== 2) return false;
+
+  const [local, domain] = parts;
+  if (!local.length || !domain.length) return false;
+
+  // Security rule: local and domain must NOT start or end with a dot
+  if (local.startsWith(".") || local.endsWith(".")) return false;
+  if (domain.startsWith(".") || domain.endsWith(".")) return false;
+
+  // Basic structure check: something@something.something
+  const basic = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return basic.test(email);
+};
+
+export const emailInvalidMessage =
+  "Proporcione un correo electrónico válido. No debe comenzar ni terminar con '.' en la parte local o en el dominio.";


### PR DESCRIPTION
Se corrigió un problema donde el campo **email** permitía ingresar direcciones que comenzaban con un punto (`.usuario@test.com`).
Según las reglas de validación, **los correos no pueden iniciar ni terminar con un punto** en la parte local ni en el dominio.

Se implementó una validación personalizada en `isValidEmail()` para cubrir estos casos, aplicándose tanto en **Login** como en **Registro**.

### Screenshots 

#### Login

![IMG_20251113_212349_539.jpg](https://github.com/user-attachments/assets/4053469f-0f82-4abf-bea3-45ef085c96b8)

#### Registro 

![IMG_20251113_212350_501.jpg](https://github.com/user-attachments/assets/c7b41e43-74ed-4a6a-9eee-fbb4b4c10ab1)

